### PR TITLE
fix: update IPLD explorer to use ipfs@0.31.0

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -154,7 +154,7 @@ export default {
     exploreIpldUrl: function () {
       let cid = this.output.test && this.output.test.cid && this.output.test.cid.toBaseEncodedString()
       cid = cid || ''
-      return `https://ipfs.io/ipfs/QmeznoNAoUcQdCFEEz4ktv4zLfYYyhVNin28Frsv8LLxCb/#/explore/${cid}`
+      return `https://ipfs.io/ipfs/QmYJETQ15RAnKXoJxqpXzcvQ2DuQA35UHwJBTjTPCSs9Ky/#/explore/${cid}`
     }
   },
   methods: {


### PR DESCRIPTION
IPLD Explorer now explores protoschool dags!

![screenshot 2018-07-29 20 53 47](https://user-images.githubusercontent.com/58871/43370168-25682850-9372-11e8-98cf-7512665c2a9a.png)


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>