### PR TITLE
fix: split exercises apart

### DIFF
--- a/src/lessons/Blog/01-exercise.md
+++ b/src/lessons/Blog/01-exercise.md
@@ -1,0 +1,1 @@
+Modify the two existing blog posts and add a new field `author` that links to the author of the blog post. The post about trees was authored by Sam and Nat wrote the post about computers. Remember to use `toBaseEncodedString()` to make the CID links.

--- a/src/lessons/Blog/01.md
+++ b/src/lessons/Blog/01.md
@@ -5,5 +5,3 @@ In the [basic lessons](#/basics/02) we learned that a link in IPLD is represente
 ```javascript
 const link = {'/': 'a-base-encoded-cid'}
 ```
-
-Modify the two existing blog posts and add a new field `author` that links to the author of the blog post. The post about trees was authored by Sam and Nat wrote the post about computers. Remember to use `toBaseEncodedString()` to make the CID links.

--- a/src/lessons/Blog/01.vue
+++ b/src/lessons/Blog/01.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-01">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="Basic linking">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './01.md'
+import exercise from './01-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 const CID = require('cids')
@@ -106,7 +109,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/02-exercise.md
+++ b/src/lessons/Blog/02-exercise.md
@@ -1,0 +1,1 @@
+Add a new field called `tags` whose value is an array of tags. Use the tags “outdoor” and “hobby” for the blog post about trees. The blog post about computers has only a single tag called “hobby”.

--- a/src/lessons/Blog/02.md
+++ b/src/lessons/Blog/02.md
@@ -2,4 +2,4 @@ Everything that is stored in IPLD has an associated CID. That CID is constructed
 
 Before modifying the code, please open the developer tools and submit the code. You’ll see the CIDs of the blog posts on the console. When you look at the console again after you’ve modified the code, you’ll see the CIDs being different.
 
-Another common thing in blogs is tagging. Let’s modify the blog posts again and add some tags. Add a new field called `tags` whose value is an array of tags. Use the tags “outdoor” and “hobby” for the blog post about trees. The blog post about computers has only a single tag called “hobby”.
+Another common thing in blogs is tagging. Let’s modify the blog posts again and add some tags.

--- a/src/lessons/Blog/02.vue
+++ b/src/lessons/Blog/02.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-02">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="CIDs change">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './02.md'
+import exercise from './02-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 
@@ -108,7 +111,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/03-exercise.md
+++ b/src/lessons/Blog/03-exercise.md
@@ -1,0 +1,1 @@
+Insert those new tag objects into IPLD via `ipld.dag.put()` and return the two resulting CIDs as array.

--- a/src/lessons/Blog/03.md
+++ b/src/lessons/Blog/03.md
@@ -21,6 +21,4 @@ This is perfect for our use case. Create a new node for the tags “outdoor” a
 }
 ```
 
-Insert those objects into IPLD via `ipld.dag.put()` and return the two resulting CIDs as array.
-
 Please note that arrays are order-dependent. This means that two arrays with the same links in a different order will get a different CID.

--- a/src/lessons/Blog/03.vue
+++ b/src/lessons/Blog/03.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-03">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="Multiple links">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './03.md'
+import exercise from './03-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 const CID = require('cids')
@@ -131,7 +134,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/04-exercise.md
+++ b/src/lessons/Blog/04-exercise.md
@@ -1,0 +1,1 @@
+Create a new blog post where the author of it is Sam, its content is about “dogs” and it is tagged as “funny” and “hobby”. Return the CID of that new blog post.

--- a/src/lessons/Blog/04.md
+++ b/src/lessons/Blog/04.md
@@ -1,4 +1,1 @@
-In order to make the DAG (Directed Acyclic Graph) a bit more interesting, we will add a new blog post. It follows the same structure as the existing ones. The author of it is Sam, its content is about “dogs” and it is tagged as “funny” and “hobby”.
-
-Return the CID of that new blog post.
-
+In order to make the DAG (Directed Acyclic Graph) a bit more interesting, we will add a new blog post. It follows the same structure as the existing ones.

--- a/src/lessons/Blog/04.vue
+++ b/src/lessons/Blog/04.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-04">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="Bigger DAG">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './04.md'
+import exercise from './04-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 const CID = require('cids')
@@ -143,7 +146,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/05-exercise.md
+++ b/src/lessons/Blog/05-exercise.md
@@ -1,0 +1,5 @@
+First, you'll need to add the new blog post to the “hobby” tag.
+
+There isn’t a node for the “funny” tag yet either, so create a new node with the same data as the other tag nodes and add a link to the blog post about dogs.
+
+Return the CIDs of all three tag nodes.

--- a/src/lessons/Blog/05.md
+++ b/src/lessons/Blog/05.md
@@ -1,7 +1,1 @@
 The previously created blog post about dogs is completely disconnected from the others. Now, update the nodes that represent the tag cloud.
-
-First, you'll need to add the new blog post to the “hobby” tag.
-
-There isn’t a node for the “funny” tag yet either, so create a new node with the same data as the other tag nodes and add a link to the blog post about dogs.
-
-Return the CIDs of all three tag nodes.

--- a/src/lessons/Blog/05.vue
+++ b/src/lessons/Blog/05.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-05">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="Keep building links">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './05.md'
+import exercise from './05-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 const CID = require('cids')
@@ -167,7 +170,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/06-exercise.md
+++ b/src/lessons/Blog/06-exercise.md
@@ -1,0 +1,3 @@
+In the code below, introduce a new field named `prev` in our blog posts. This field links to the previous blog post.
+
+Link the blog posts in chronological order. The oldest one is the one about trees, then there’s the one about computers. The one about “dogs” is the newest one. Once you’ve updated them, return the CID of the blog post about “dogs”.

--- a/src/lessons/Blog/06.md
+++ b/src/lessons/Blog/06.md
@@ -5,7 +5,3 @@ You *could* do it the same way as we did with tags. However, you would need to u
 There’s a better way! Whenever you create a new blog post, you can link to the previous one directly. You can walk those links to create the overview page dynamically (which we’ll do in the next exercise).
 
 We know the CID of a blog post as soon as it is stored in IPLD. We can use that CID to link from newer blog posts to older ones.
-
-In the code below, introduce a new field named `prev` in our blog posts. This field links to the previous blog post.
-
-Link the blog posts in chronological order. The oldest one is the one about trees, then there’s the one about computers. The one about “dogs” is the newest one. Once you’ve updated them, return the CID of the blog post about “dogs”.

--- a/src/lessons/Blog/06.vue
+++ b/src/lessons/Blog/06.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="lesson-blog-06">
-    <Lesson v-bind:text="text" v-bind:code="code" :validate="validate"
+    <Lesson v-bind:text="text" v-bind:code="code"
+            :validate="validate"
+            :exercise="exercise"
             lessonTitle="Chain of links">
     </Lesson>
   </div>
@@ -9,6 +11,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './06.md'
+import exercise from './06-exercise.md'
 const CID = require('cids')
 
 const code = `/* globals ipfs */
@@ -186,7 +189,8 @@ export default {
     return {
       code,
       text,
-      validate
+      validate,
+      exercise
     }
   }
 }

--- a/src/lessons/Blog/07-exercise.md
+++ b/src/lessons/Blog/07-exercise.md
@@ -1,0 +1,1 @@
+Fill in the body of the `traversePosts()` function. It takes the CID object of the most recent blog post as input. Use that to get the object from IPFS and follow the `prev` links. The return value of the function should be an array with the CID objects of all nodes (including the input CID).

--- a/src/lessons/Blog/07.md
+++ b/src/lessons/Blog/07.md
@@ -9,5 +9,3 @@ let cid = new CID((await ipfs.dag.get(someCid)).value.linkName['/'])
 ```
 
 This kind of traversal could be used to create an overview page that lists all blog posts.
-
-Fill in the body of the `traversePosts()` function. It takes the CID object of the most recent blog post as input. Use that to get the object from IPFS and follow the `prev` links. The return value of the function should be an array with the CID objects of all nodes (including the input CID).

--- a/src/lessons/Blog/07.vue
+++ b/src/lessons/Blog/07.vue
@@ -3,6 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :modules="modules"
+            :exercise="exercise"
             lessonTitle="Hop through nodes">
     </Lesson>
   </div>
@@ -11,6 +12,7 @@
 <script>
 import Lesson from '../../components/Lesson'
 import text from './07.md'
+import exercise from './07-exercise.md'
 import utils from './utils.js'
 const shallowEqualArrays = require('shallow-equal/arrays')
 const CID = require('cids')
@@ -182,7 +184,8 @@ export default {
       code,
       text,
       validate,
-      modules
+      modules,
+      exercise
     }
   }
 }


### PR DESCRIPTION
The layout with splitting the exercises into its own files
is way nicer. Do this for the blog lessons.