### PR TITLE
Rename lessons & change IPLD mentions to IPFS

### DIFF
--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -30,7 +30,7 @@
           <svg viewBox="0 0 12 12" width='12' xmlns="http://www.w3.org/2000/svg" style='vertical-align:-1px'>
             <circle cx="6" cy="6" r="6"/>
           </svg>
-          <span class="green ttu f6 pl2 pr3">Exercise {{lessonNumber}}</span>
+          <span class="green ttu f6 pl2 pr3">Exercise</span>
           <span class="navy fw5 f5">{{lessonTitle}}</span>
           <div class="fr">
             <button

--- a/src/components/home/ExerciseLink.vue
+++ b/src/components/home/ExerciseLink.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link :to="to" class="link db pa3 bb b--white green hover-bg-washed-yellow">
-    <span class="green ttu f6 pr3">Exercise {{index}}</span>
+    <span class="green ttu f6 pr3">Lesson {{index}}</span>
     <span class="navy fw5">{{name}}</span>
   </router-link>
 </template>

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -31,13 +31,13 @@
       </label>
       <div class="flex items-start pv4">
         <div class="section-1 flex-none tc">
-          <h1 class="ma0 f3 fw6 pb2">IPLD</h1>
-          <img src="./ipld.svg" alt="" style="height: 54px"/>
+          <h1 class="ma0 f3 fw6 pb2">IPFS</h1>
+          <img src="./ipfs.svg" alt="" style="height: 54px"/>
         </div>
         <div class="w-100 w-50-ns measure-wide ph2 ph0-ns">
           <h2 class="ma0 f3 fw5">P2P data links with content addressing</h2>
           <p class="f5 fw5 ma0 pt2 lh-copy measure-wide charcoal-muted">
-            Store, fetch, and create verifiable links between peer-hosted datasets with IPLD and CIDs. It’s graphs with friends!
+            Store, fetch, and create verifiable links between peer-hosted datasets with IPFS and CIDs. It’s graphs with friends!
           </p>
           <ul class="mv4 pa0 f5" style="list-style-type: none; background: rgba(11, 58, 82, 5%)">
             <li>
@@ -59,8 +59,8 @@
     <section class="db">
       <div class="flex items-start pv4">
         <div class="section-1 flex-none tc">
-          <h1 class="ma0 f3 fw6 pb2">IPLD</h1>
-          <img src="./ipld.svg" alt="" style="height: 54px"/>
+          <h1 class="ma0 f3 fw6 pb2">IPFS</h1>
+          <img src="./ipfs.svg" alt="" style="height: 54px"/>
         </div>
         <div class="w-100 w-50-ns measure-wide ph2 ph0-ns">
           <h2 class="ma0 f3 fw5 ">Blogging on the Decentralized Web</h2>

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -41,13 +41,13 @@
           </p>
           <ul class="mv4 pa0 f5" style="list-style-type: none; background: rgba(11, 58, 82, 5%)">
             <li>
-              <ExerciseLink to="/basics/01" index="1" name="Basic write" />
+              <ExerciseLink to="/basics/01" index="1" name="Create a node and return a Content Identifier (CID)" />
             </li>
             <li>
-              <ExerciseLink to="/basics/02" index="2" name="Linking data" />
+              <ExerciseLink to="/basics/02" index="2" name="Create a new node that's linked to an old one" />
             </li>
             <li>
-              <ExerciseLink to="/basics/03" index="3" name="Reading data in links" />
+              <ExerciseLink to="/basics/03" index="3" name="Read nested data using links" />
             </li>
           </ul>
         </div>

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -69,25 +69,25 @@
           </p>
           <ul class="mv4 pa0 f5" style="list-style-type: none; background: rgba(11, 58, 82, 5%)">
             <li>
-              <ExerciseLink to="/blog/01" index="1" name="Basic linking" />
+              <ExerciseLink to="/blog/01" index="1" name="Link an author to a blog post using its CID" />
             </li>
             <li>
-              <ExerciseLink to="/blog/02" index="2" name="CIDs change" />
+              <ExerciseLink to="/blog/02" index="2" name="Update posts with tags and watch their CIDs change" />
             </li>
             <li>
-              <ExerciseLink to="/blog/03" index="3" name="Multiple links" />
+              <ExerciseLink to="/blog/03" index="3" name="Build a tag cloud with arrays of links" />
             </li>
             <li>
-              <ExerciseLink to="/blog/04" index="4" name="Bigger DAG" />
+              <ExerciseLink to="/blog/04" index="4" name="Add a new blog post linked to an author and tags" />
             </li>
             <li>
-              <ExerciseLink to="/blog/05" index="5" name="Keep building links" />
+              <ExerciseLink to="/blog/05" index="5" name="Add a new tag linked to multiple blog posts" />
             </li>
             <li>
-              <ExerciseLink to="/blog/06" index="6" name="Chain of links" />
+              <ExerciseLink to="/blog/06" index="6" name="List posts chronologically with a chain of links" />
             </li>
             <li>
-              <ExerciseLink to="/blog/07" index="7" name="Hop through nodes" />
+              <ExerciseLink to="/blog/07" index="7" name="Traverse through all posts, starting with the most recent" />
             </li>
           </ul>
         </div>

--- a/src/components/home/ipfs.svg
+++ b/src/components/home/ipfs.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" style="enable-background:new" xmlns="http://www.w3.org/2000/svg" xmlns:osb="http://www.openswatchbook.org/uri/2009/osb" height="512" width="512" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 511.99999 511.99998" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<defs>
+<linearGradient id="b" y2="771.51" gradientUnits="userSpaceOnUse" x2="527.72" y1="771.51" x1="84.315">
+<stop stop-color="#4a9ea1" offset="0"/>
+</linearGradient>
+<linearGradient id="a" y2="771.48" gradientUnits="userSpaceOnUse" x2="512.36" y1="771.48" x1="99.675">
+<stop stop-color="#63d3d7" offset="0"/>
+</linearGradient>
+</defs>
+<g transform="translate(-50.017 -515.51)">
+<path d="m84.315 899.51 221.7 128 221.7-128v-256l-221.7-127.99-221.7 128z" fill="url(#b)"/>
+<path fill="url(#a)" d="m283.13 546.35-160.74 92.806c0.32126 2.8543 0.32125 5.7352 0 8.5894l160.75 92.806c13.554-10.001 32.043-10.001 45.597 0l160.75-92.807c-0.32126-2.8543-0.32293-5.7338-0.001-8.588l-160.74-92.806c-13.554 10.001-32.044 10.001-45.599 0zm221.79 127.03-160.92 93.84c1.884 16.739-7.3611 32.751-22.799 39.489l0.18062 184.58c2.6325 1.1489 5.1267 2.5886 7.438 4.294l160.75-92.805c-1.884-16.739 7.3611-32.752 22.799-39.49v-185.61c-2.6325-1.1489-5.1281-2.5886-7.4394-4.294zm-397.81 1.0315c-2.3112 1.7054-4.8054 3.1465-7.438 4.2954v185.61c15.438 6.7378 24.683 22.75 22.799 39.489l160.74 92.806c2.3112-1.7054 4.8069-3.1465 7.4394-4.2954v-185.61c-15.438-6.7378-24.683-22.75-22.799-39.489l-160.74-92.81z"/>
+</g>
+<g transform="translate(0 -196.66)">
+<path d="m256 708.66 221.7-128v-256l-221.7 128v256z" fill-opacity=".25098"/>
+<path d="m256 708.66v-256l-221.7-128v256l221.7 128z" fill-opacity=".039216"/>
+<path d="m34.298 324.66 221.7 128 221.7-128-221.7-128-221.7 128z" fill-opacity=".13018"/>
+</g>
+</svg>

--- a/src/lessons/Basics/01.vue
+++ b/src/lessons/Basics/01.vue
@@ -2,7 +2,7 @@
   <div class="lesson-01">
     <Lesson :text="text" :validate="validate"
             :exercise="exercise" :concepts="concepts"
-            lessonTitle="Basic write">
+            lessonTitle="Create a node and return a Content Identifier (CID)">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Basics/02.vue
+++ b/src/lessons/Basics/02.vue
@@ -5,7 +5,7 @@
             :modules="modules"
             :exercise="exercise"
             :concepts="concepts"
-            lessonTitle="Linking data">
+            lessonTitle="Create a new node that's linked to an old one">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Basics/03.md
+++ b/src/lessons/Basics/03.md
@@ -13,7 +13,7 @@ console.log(await ipfs.dag.get(cid, '/my/deep/obj'))
 /* prints {value: 'is cool', remainderPath: ''} */
 ```
 
-`ipfs.dag.get()` allows queries using IPLD paths.
+`ipfs.dag.get()` allows queries using IPFS paths.
 These queries return an object containing the value of the query and any remaining path that was unresolved.
 
 The cool thing about this API is that it can also traverse through links.

--- a/src/lessons/Basics/03.vue
+++ b/src/lessons/Basics/03.vue
@@ -4,7 +4,7 @@
             :validate="validate"
             :modules="modules"
             :exercise="exercise"
-            lessonTitle="Reading data in links"
+            lessonTitle="Read nested data using links"
             last="true">
     </Lesson>
   </div>

--- a/src/lessons/Blog/01.md
+++ b/src/lessons/Blog/01.md
@@ -1,6 +1,6 @@
 This exercise has some prepared code to get started faster. It resembles a blog. There are authors (Nat and Sam) and some blog posts about trees and computers. At the moment there’s no relation between them. Let’s update the blog posts so that they link to the author.
 
-In the [basic lessons](#/basics/02), we learned that a link in IPLD is represented as an object with a slash as its only field:
+In the [basic lessons](#/basics/02), we learned that a link in IPFS is represented as an object with a slash as its only field:
 
 ```javascript
 const link = {'/': 'a-base-encoded-cid'}

--- a/src/lessons/Blog/01.vue
+++ b/src/lessons/Blog/01.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="Basic linking">
+            lessonTitle="Link an author to a blog post using its CID">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/02.md
+++ b/src/lessons/Blog/02.md
@@ -1,4 +1,4 @@
-Everything that is stored in IPLD has an associated CID. That CID is constructed by hashing the data itself. If the same hash and encoding is used, then the same data will result in the same CID. This means that as soon as you edit data and store it, it will have a new CID. The old data won’t be overridden; it’s still there.
+Everything that is stored in IPFS has an associated CID. That CID is constructed by hashing the data itself. If the same hash and encoding is used, then the same data will result in the same CID. This means that as soon as you edit data and store it, it will have a new CID. The old data won’t be overridden; it’s still there.
 
 Before modifying the code, please open the developer tools in your browser and submit the code. You’ll see the CIDs of the blog posts in the console. When you look at the console again after you’ve modified the code, you’ll see the CIDs have changed.
 

--- a/src/lessons/Blog/02.vue
+++ b/src/lessons/Blog/02.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="CIDs change">
+            lessonTitle="Update posts with tags and watch their CIDs change">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/03-exercise.md
+++ b/src/lessons/Blog/03-exercise.md
@@ -1,1 +1,1 @@
-Insert those new tag objects into IPLD via `ipfs.dag.put()` and return the two resulting CIDs as an array.
+Insert those new tag objects into IPFS via `ipfs.dag.put()` and return the two resulting CIDs as an array.

--- a/src/lessons/Blog/03.vue
+++ b/src/lessons/Blog/03.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="Multiple links">
+            lessonTitle="Build a tag cloud with arrays of links">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/04.vue
+++ b/src/lessons/Blog/04.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="Bigger DAG">
+            lessonTitle="Add a new blog post linked to an author and tags">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/05.vue
+++ b/src/lessons/Blog/05.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="Keep building links">
+            lessonTitle="Add a new tag linked to multiple blog posts">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/06.md
+++ b/src/lessons/Blog/06.md
@@ -4,4 +4,4 @@ You *could* do it the same way as we did with tags. However, you would need to u
 
 There’s a better way! Whenever you create a new blog post, you can link to the previous one directly. You can walk those links to create the overview page dynamically (which we’ll do in the next exercise).
 
-We know the CID of a blog post as soon as it is stored in IPLD. We can use that CID to link from newer blog posts to older ones.
+We know the CID of a blog post as soon as it is stored in IPFS. We can use that CID to link from newer blog posts to older ones.

--- a/src/lessons/Blog/06.vue
+++ b/src/lessons/Blog/06.vue
@@ -3,7 +3,7 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :exercise="exercise"
-            lessonTitle="Chain of links">
+            lessonTitle="List posts chronologically with a chain of links">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/07.vue
+++ b/src/lessons/Blog/07.vue
@@ -4,7 +4,7 @@
             :validate="validate"
             :modules="modules"
             :exercise="exercise"
-            lessonTitle="Hop through nodes"
+            lessonTitle="Traverse through all posts, starting with the most recent"
             last="true">
     </Lesson>
   </div>


### PR DESCRIPTION
This PR should fully address: 
- Issue #67 by changing references to IPLD to IPFS, including logos
- Issue #69 by labelling each subset of a workshop a "lesson" and removing exercise numbers, as well as creating what I hope are more compelling and descriptive lesson titles

This needs a thorough review from @mikeal to ensure the direct replacements of IPLD with IPFS are acceptable as is without any additional rewording. Note that I did _not_ edit the references to "IPLD Explorer." 

I'm very open to feedback from @mikeal @vmx et al on the new proposals for lesson titles.