### PR TITLE
Calculate/display workshop, lesson #, lesson total

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ of the lesson.
 
 Add your lesson to the routes in `main.js` and to the list of lessons in `Home.vue`.
 
+When adding your routes, it's important that you follow the existing naming
+convention, since the code used elsewhere will parse the route path to determine the
+shortname of the workshop, the current lesson number, and the total number of
+lessons in your workshop. For example, if you add 3 lessons with the following routes:
+
+```
+{ path: '/basics/01', component: LessonBasics01 },
+{ path: '/basics/02', component: LessonBasics02 },
+{ path: '/basics/03', component: LessonBasics03 },
+```
+your second lesson will display the following under the lesson title:
+
+`Basics | Lesson 2 of 3`
+
 ## Boiler Explained
 
 ```javascript

--- a/src/components/Lesson.vue
+++ b/src/components/Lesson.vue
@@ -16,6 +16,7 @@
     <div class="flex-l items-start bt border-aqua bw4">
       <section class="pv3 indent-1">
         <h1 class="f3 measure-wide">{{lessonTitle}}</h1>
+        <span class="green"><span class="b">{{workshopShortname}}</span> | Lesson {{lessonNumber}} of {{lessonsInWorkshop}}</span>
         <div class="lesson-text lh-copy measure-wide" v-html="parsedText"></div>
       </section>
       <section v-if="concepts" class='dn db-ns ba border-green ph4 ml3 ml5-l mt5 mb3 mr3 measure' style="background: rgba(105, 196, 205, 10%)">
@@ -86,7 +87,7 @@
           </div>
         </div>
         <div class="pt3 ph2 tr">
-          <div v-if="output.test && output.test.success && last === 'true'">
+          <div v-if="output.test && output.test.success && lessonNumber === lessonsInWorkshop">
             <Button v-bind:click="workshopMenu" class="bg-aqua white">More Workshops</Button>
           </div>
           <div v-else-if="output.test && output.test.success">
@@ -176,7 +177,6 @@ export default {
       text: self.$attrs.text,
       exercise: self.$attrs.exercise,
       concepts: self.$attrs.concepts,
-      last: self.$attrs.last,
       code: self.$attrs.code || defaultCode,
       parsedText: marked(self.$attrs.text),
       parsedExercise: marked(self.$attrs.exercise || ''),
@@ -201,7 +201,19 @@ export default {
       return `https://ipfs.io/ipfs/QmYJETQ15RAnKXoJxqpXzcvQ2DuQA35UHwJBTjTPCSs9Ky/#/explore/${cid}`
     },
     lessonNumber: function () {
-      return this.$route.path.slice(this.$route.path.lastIndexOf('/') + 1)
+      return parseInt(this.$route.path.slice(this.$route.path.lastIndexOf('/') + 1), 10)
+    },
+    workshopShortname: function () {
+      return this.$route.path.charAt(1).toUpperCase() + this.$route.path.slice(2, this.$route.path.lastIndexOf('/'))
+    },
+    lessonsInWorkshop: function () {
+      let basePath = this.$route.path.slice(0, -2)
+      let number = this.$route.path.slice(-2)
+      while (this.$router.resolve(basePath + number).route.name !== '404') {
+        number ++
+        number = number.toString().padStart(2, '0')
+      }
+      return parseInt(number) - 1
     },
     editorHeight: function () {
       if (this.expandExercise) {

--- a/src/lessons/Basics/03.vue
+++ b/src/lessons/Basics/03.vue
@@ -4,8 +4,7 @@
             :validate="validate"
             :modules="modules"
             :exercise="exercise"
-            lessonTitle="Read nested data using links"
-            last="true">
+            lessonTitle="Read nested data using links">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/Blog/07.vue
+++ b/src/lessons/Blog/07.vue
@@ -4,8 +4,7 @@
             :validate="validate"
             :modules="modules"
             :exercise="exercise"
-            lessonTitle="Traverse through all posts, starting with the most recent"
-            last="true">
+            lessonTitle="Traverse through all posts, starting with the most recent">
     </Lesson>
   </div>
 </template>

--- a/src/lessons/boiler.vue
+++ b/src/lessons/boiler.vue
@@ -3,7 +3,8 @@
     <Lesson v-bind:text="text" v-bind:code="code"
             :validate="validate"
             :modules="modules"
-    >
+            :exercise="exercise"
+            lessonTitle="REPLACEME">
     </Lesson>
   </div>
 </template>
@@ -11,6 +12,7 @@
 <script>
 import Lesson from '../components/Lesson'
 import text from './REPLACEME.md'
+import exercise from './REPLACEME-exercise.md'
 
 const validate = async (result, ipfs) => {
   if (result) {

--- a/src/main.js
+++ b/src/main.js
@@ -6,9 +6,9 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import App from './App.vue'
 import Home from './components/home/Home.vue'
-import Lesson01 from './lessons/Basics/01.vue'
-import Lesson02 from './lessons/Basics/02.vue'
-import Lesson03 from './lessons/Basics/03.vue'
+import LessonBasics01 from './lessons/Basics/01.vue'
+import LessonBasics02 from './lessons/Basics/02.vue'
+import LessonBasics03 from './lessons/Basics/03.vue'
 import LessonBlog01 from './lessons/Blog/01.vue'
 import LessonBlog02 from './lessons/Blog/02.vue'
 import LessonBlog03 from './lessons/Blog/03.vue'
@@ -21,16 +21,17 @@ Vue.use(VueRouter)
 
 const routes = [
   { path: '/', component: Home },
-  { path: '/basics/01', component: Lesson01 },
-  { path: '/basics/02', component: Lesson02 },
-  { path: '/basics/03', component: Lesson03 },
+  { path: '/basics/01', component: LessonBasics01 },
+  { path: '/basics/02', component: LessonBasics02 },
+  { path: '/basics/03', component: LessonBasics03 },
   { path: '/blog/01', component: LessonBlog01 },
   { path: '/blog/02', component: LessonBlog02 },
   { path: '/blog/03', component: LessonBlog03 },
   { path: '/blog/04', component: LessonBlog04 },
   { path: '/blog/05', component: LessonBlog05 },
   { path: '/blog/06', component: LessonBlog06 },
-  { path: '/blog/07', component: LessonBlog07 }
+  { path: '/blog/07', component: LessonBlog07 },
+  { path: '*', name: '404' }
 ]
 
 const router = new VueRouter({


### PR DESCRIPTION
Closes #62 and closes #70 by programmatically interpreting the route path to determine the shortname of the workshop ("Basics" or "Blog"), the lesson number, and the total number of lessons in the current workshop, without the author of a new workshop having to add this info explicitly. This also removes the need for the author to add a "last: true" property to make the button on the final lesson of the series work properly. 

Note that the current solution will only work if we stick with our current pattern for paths (eg "/basics/02"), picking one-word shortnames for workshops. If we need to deviate from this pattern down the road, the "workshopShortname" calculated value will need to be adjusted, but this could be done without much difficulty if we consistently use hyphens or something like that to allow us to easily manipulate the string.

For now I'm doing a very simple presentation rather than a visual progress bar. (We can re-assess whether we want to do a progress bar once we build the ability to save state.) Here's the visual change you should see on each lesson page: 

![image](https://user-images.githubusercontent.com/19171465/48632638-6c37ee00-e98f-11e8-95e5-c3b4c826b5b6.png)


Updates: 
- In `Lesson.vue`, calculate `lessonNumber` and `workshopShortname`
from route path (removing trailing zeros in lesson number and
capitalizing first letter of workshop name)
- In `Lesson.vue`, calculate total `lessonsInWorkshop `by
incrementing path and checking if that route exists until it doesn't
- Calculate whether you're in the final lesson by checking if
`lessonNumber` equals `lessonsInWorkshop`, so it's no longer
necessary to pass a `last: true` (that property removed now from relevant
lessons)
- In `main.js`, adjust route names for consistency to include shortname
of workshop
- Update `boiler.vue` to match current needs
- Display "Workshop | Lesson X of Y" under lesson name