### PR TITLE
Fix wrapping of lesson titles on homepage

### DIFF
--- a/src/components/home/ExerciseLink.vue
+++ b/src/components/home/ExerciseLink.vue
@@ -1,7 +1,9 @@
 <template>
   <router-link :to="to" class="link db pa3 bb b--white green hover-bg-washed-yellow">
-    <span class="green ttu f6 pr3">Lesson {{index}}</span>
-    <span class="navy fw5">{{name}}</span>
+    <div class="flex">
+      <div class="green ttu f6 pr3" style="min-width: 83px">Lesson {{index}}</div>
+      <div class="navy fw5 mw6">{{name}}</div>
+    </div>
   </router-link>
 </template>
 

--- a/src/components/home/Home.vue
+++ b/src/components/home/Home.vue
@@ -34,7 +34,7 @@
           <h1 class="ma0 f3 fw6 pb2">IPFS</h1>
           <img src="./ipfs.svg" alt="" style="height: 54px"/>
         </div>
-        <div class="w-100 w-50-ns measure-wide ph2 ph0-ns">
+        <div class="w-100 w-50-l measure-wide ph2 ph0-l">
           <h2 class="ma0 f3 fw5">P2P data links with content addressing</h2>
           <p class="f5 fw5 ma0 pt2 lh-copy measure-wide charcoal-muted">
             Store, fetch, and create verifiable links between peer-hosted datasets with IPFS and CIDs. It’s graphs with friends!
@@ -51,7 +51,7 @@
             </li>
           </ul>
         </div>
-        <div class="dn db-ns flex-auto tc">
+        <div class="dn db-l flex-auto tc">
           <img src="./ipfs-illustrations-how-1.svg" alt="">
         </div>
       </div>
@@ -62,7 +62,7 @@
           <h1 class="ma0 f3 fw6 pb2">IPFS</h1>
           <img src="./ipfs.svg" alt="" style="height: 54px"/>
         </div>
-        <div class="w-100 w-50-ns measure-wide ph2 ph0-ns">
+        <div class="w-100 w-50-l measure-wide ph2 ph0-l">
           <h2 class="ma0 f3 fw5 ">Blogging on the Decentralized Web</h2>
           <p class="f5 fw5 ma0 pt2 lh-copy charcoal-muted">
             Cool content addresses don't change.
@@ -91,7 +91,7 @@
             </li>
           </ul>
         </div>
-        <div class="dn db-ns flex-auto tc">
+        <div class="dn db-l flex-auto tc">
           <img src="./ipfs-illustrations-how-4.svg" alt="">
         </div>
       </div>


### PR DESCRIPTION
Closes #77 by preventing lesson titles from wrapping to under lesson numbers at narrower screen widths. 

Previous state: 
![image](https://user-images.githubusercontent.com/19171465/48637953-30a42080-e99d-11e8-96c2-2bc9606d04e4.png)

New state: 
![image](https://user-images.githubusercontent.com/19171465/48638004-5af5de00-e99d-11e8-8ca6-6b04e0ea7d3b.png)

@mikeal @olizilla When testing, please adjust your screen width and ensure that the green "LESSON X" never wraps its numeral down to a second line. Only the text titles should wrap.

Note that I also changed the point at which the illustrations to the right of the lesson lists disappear, since they were limiting the space available at medium window widths.
